### PR TITLE
Fix wildcard protocol routes

### DIFF
--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -169,8 +169,10 @@ module.exports.createPages = async ({ actions, graphql }) => {
   pages.forEach((page) => {
     const { id, fields, html } = page
 
+    let matchPath = fields.slug + '*'
     actions.createPage({
       path: fields.slug,
+      matchPath: matchPath,
       component: protocolTemplate,
       context: {
         id,


### PR DESCRIPTION
This fixes issue #20.

Now any routes after the protocol will return the protocol page.

E.g. https://didcomm.org/basicmessage/2.0/some/route

