### PR TITLE
WACI Pex

### DIFF
--- a/site/content/protocols/issue-credential/1.1/readme.md
+++ b/site/content/protocols/issue-credential/1.1/readme.md
@@ -1,0 +1,16 @@
+---
+title: Issue Credential
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/issue-credential/1.1
+status: Production
+summary: Formalizes messages used to issue a credential, whether the credential is JWT-oriented, JSON-LD-oriented, or ZKP-oriented.
+tags: []
+authors:
+  - name: Nikita Khateev
+
+---
+
+## Details
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0036-issue-credential

--- a/site/content/protocols/issue-credential/2.0/readme.md
+++ b/site/content/protocols/issue-credential/2.0/readme.md
@@ -1,0 +1,18 @@
+---
+title: Issue Credential
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/issue-credential/2.0
+status: Production
+summary: Formalizes messages used to issue a credential, whether the credential is JWT-oriented, JSON-LD-oriented, or ZKP-oriented.
+tags: []
+authors:
+  - name: Nikita Khateev
+  - name: Stephen Klump
+  - name: Stephen Curran
+
+---
+
+## Details
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0453-issue-credential-v2

--- a/site/content/protocols/issue-credential/3.0/readme.md
+++ b/site/content/protocols/issue-credential/3.0/readme.md
@@ -1,0 +1,21 @@
+---
+title: Issue Credential
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/issue-credential/3.0
+status: Draft
+summary: Formalizes messages used to issue a credential, whether the credential is JWT-oriented, JSON-LD-oriented, or ZKP-oriented.
+tags: []
+authors:
+  - name: Nikita Khateev
+  - name: Stephen Klump
+  - name: Stephen Curran
+  - name: Rolson Quadras
+
+---
+
+## Details
+
+This protocol is proposed here: https://github.com/decentralized-identity/waci-didcomm/tree/main/issue_credential
+
+It is part of WACI-DIDComm Interop Profile v1.0, colloqually known as WACI PEx, a DIDComm v2 profile for supporting the Wallet and Credential Interaction (WACI) Protocols for both Issuance and Presentation Exchange. It is defined here: https://identity.foundation/waci-didcomm/v1.0/

--- a/site/content/protocols/present-proof/1.0/readme.md
+++ b/site/content/protocols/present-proof/1.0/readme.md
@@ -1,0 +1,16 @@
+---
+title: Present Proof
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/present-proof/1.0
+status: Production
+summary: A protocol supporting a general purpose verifiable presentation exchange regardless of the specifics of the underlying verifiable presentation request and verifiable presentation format.
+tags: []
+authors:
+  - name: Nikita Khateev
+
+---
+
+## Details
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0037-present-proof

--- a/site/content/protocols/present-proof/2.0/readme.md
+++ b/site/content/protocols/present-proof/2.0/readme.md
@@ -1,0 +1,17 @@
+---
+title: Present Proof
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/present-proof/2.0
+status: Production
+summary: A protocol supporting a general purpose verifiable presentation exchange regardless of the specifics of the underlying verifiable presentation request and verifiable presentation format.
+tags: []
+authors:
+  - name: Nikita Khateev
+  - name: Stephen Curran
+
+---
+
+## Details
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0454-present-proof-v2

--- a/site/content/protocols/present-proof/3.0/readme.md
+++ b/site/content/protocols/present-proof/3.0/readme.md
@@ -1,0 +1,20 @@
+---
+title: Present Proof
+publisher: rodolfomiranda
+license: MIT
+piuri: https://didcomm.org/present-proof/3.0
+status: Draft
+summary: A protocol supporting a general purpose verifiable presentation exchange regardless of the specifics of the underlying verifiable presentation request and verifiable presentation format.
+tags: []
+authors:
+  - name: Nikita Khateev
+  - name: Stephen Curran
+  - name: Sam Curren
+
+---
+
+## Details
+
+This protocol is proposed here: https://github.com/decentralized-identity/waci-didcomm/blob/main/present_proof/present-proof-v3.md
+
+It is part of WACI-DIDComm Interop Profile v1.0, colloqually known as WACI PEx, a DIDComm v2 profile for supporting the Wallet and Credential Interaction (WACI) Protocols for both Issuance and Presentation Exchange. It is defined here: https://identity.foundation/waci-didcomm/v1.0/


### PR DESCRIPTION
Adding Issue Credential and Present Proof 1.0, 2.0 and 3.0. The latest version with draft status with links to [WACI PEx](https://identity.foundation/waci-didcomm/v1.0/) profile.