### PR TITLE
Fix example in Mediator protocols

### DIFF
--- a/site/content/protocols/mediator-coordination/2.0/readme.md
+++ b/site/content/protocols/mediator-coordination/2.0/readme.md
@@ -98,7 +98,7 @@ Message Type URI: `https://didcomm.org/coordinate-mediation/2.0/mediate-grant`
     "type": "https://didcomm.org/coordinate-mediation/2.0/mediate-grant",
     "body": 
             {
-                "routing_did": ["did:peer:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"]
+                "routing_did": "did:peer:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"
             }
 }
 ```
@@ -213,6 +213,7 @@ where:
 No localization is required.
 
 ## Implementations
+[RootsID DIDComm v2 Mediator](https://github.com/roots-id/didcomm-mediator)
 
 ## Endnotes
 

--- a/site/content/protocols/pickup/3.0/readme.md
+++ b/site/content/protocols/pickup/3.0/readme.md
@@ -244,6 +244,7 @@ If sent with `live_delivery` set to true on a connection incapable of live deliv
 No localization is required.
 
 ## Implementations
+[RootsID DIDComm v2 Mediator](https://github.com/roots-id/didcomm-mediator)
 
 ## Endnotes
 


### PR DESCRIPTION
Remove a [ ] at routing_did.
We also added, as an implementation reference, a Mediator Prototype we built at RootsID. We are also hosting a cloud mediator for testing/learning purposes and providing sample agents in python notebooks to play with the workflow. Lot of work still to be developed in order to be complete though. 

