### PR TITLE
Trying to avoid emoji insertion on webpage

### DIFF
--- a/site/content/protocols/mediator-coordination/2.0/readme.md
+++ b/site/content/protocols/mediator-coordination/2.0/readme.md
@@ -119,7 +119,7 @@ Message Type URI: `https://didcomm.org/coordinate-mediation/2.0/keylist-update`
             {
                 "updates":  [
                                 {
-                                    "recipient_did": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+                                    "recipient_did": `did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH`,
                                     "action": "add"
                                 }
                             ]
@@ -144,7 +144,7 @@ Message Type URI: `https://didcomm.org/coordinate-mediation/2.0/keylist-update-r
             {
                 "updated":  [
                                 {
-                                    "recipient_did": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+                                    "recipient_did": `did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH`,
                                     "action": "" // "add" or "remove"
                                     "result": "" // [client_error | server_error | no_change | success]
                                 }
@@ -193,7 +193,7 @@ Message Type URI: `https://didcomm.org/coordinate-mediation/2.0/keylist`
             {
                 "keys": [
                             {
-                                "recipient_did": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                                "recipient_did": `did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH`
                             }
                         ]
                 "pagination":   {


### PR DESCRIPTION
the markup looks good on github but on didcomm.org it was trying to render an emoji that is a very confusing set of embedded xml, that is certainly a bug.
<img width="823" alt="image" src="https://user-images.githubusercontent.com/681493/203610344-48a0420a-a46f-46aa-9b27-bcf911e50762.png">
