### PR TITLE
fix: naming consistencies for message pickup protocol

### DIFF
--- a/site/content/protocols/messagepickup/1.0/readme.md
+++ b/site/content/protocols/messagepickup/1.0/readme.md
@@ -1,5 +1,5 @@
 ---
-title: Pickup
+title: Message Pickup
 publisher: rodolfomiranda
 license: MIT
 piuri: https://didcomm.org/messagepickup/1.0
@@ -16,4 +16,4 @@ authors:
 
 This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0212-pickup
 
-Note: as pointed in the abovementioned link, the version of this protocol is 1.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that there’s a new 3.0 version of this protocol that complies also with DIDComm v2 headers. Version 3.0 can be found [here](https://didcomm.org/pickup/3.0/)
+Note: as pointed in the abovementioned link, the version of this protocol is 1.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that there’s a new 3.0 version of this protocol that complies also with DIDComm v2 headers. Version 3.0 can be found [here](https://didcomm.org/messagepickup/3.0/)

--- a/site/content/protocols/messagepickup/2.0/readme.md
+++ b/site/content/protocols/messagepickup/2.0/readme.md
@@ -1,5 +1,5 @@
 ---
-title: Pickup
+title: Message Pickup
 publisher: rodolfomiranda
 license: MIT
 piuri: https://didcomm.org/messagepickup/2.0
@@ -19,4 +19,4 @@ authors:
 
 This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/main/features/0685-pickup-v2
 
-Note: as pointed in the abovementioned link, the version of this protocol is 2.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that there’s a new 3.0 version of this protocol that complies also with DIDComm v2 headers. Version 3.0 can be found [here](https://didcomm.org/pickup/3.0/)
+Note: as pointed in the abovementioned link, the version of this protocol is 2.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that there’s a new 3.0 version of this protocol that complies also with DIDComm v2 headers. Version 3.0 can be found [here](https://didcomm.org/messagepickup/3.0/)

--- a/site/content/protocols/messagepickup/3.0/readme.md
+++ b/site/content/protocols/messagepickup/3.0/readme.md
@@ -1,5 +1,5 @@
 ---
-title: Pickup
+title: Message Pickup
 publisher: rodolfomiranda
 license: MIT
 piuri: https://didcomm.org/messagepickup/3.0


### PR DESCRIPTION
This corrects some inconsistencies in naming for the Message Pickup Protocol, perferring the naming in the Protocol Identifier URI.

This is the other half of #96 (that I missed in the PR that closed that issue).