### PR TITLE
fix: empty goal code table in protocols

### DIFF
--- a/site/content/protocols/action-menu/2.0/readme.md
+++ b/site/content/protocols/action-menu/2.0/readme.md
@@ -66,10 +66,6 @@ This protocol expects messages to be encrypted during transmission, and repudiab
 
 Supported Goal Code | Notes
 --- | ---
-                     |       
-                     |       
-
-
 
 ## Message Reference
 

--- a/site/content/protocols/basicmessage/2.0/readme.md
+++ b/site/content/protocols/basicmessage/2.0/readme.md
@@ -42,9 +42,6 @@ This protocol expects messages to be encrypted during transmission, and repudiab
 
 Supported Goal Code | Notes
 --- | ---
-                     |       
-                     |       
-
 
 
 ## Message Reference

--- a/site/content/protocols/coordinate-mediation/2.0/readme.md
+++ b/site/content/protocols/coordinate-mediation/2.0/readme.md
@@ -62,8 +62,6 @@ This protocol expects messages to be encrypted during transmission, and repudiab
 
 Supported Goal Code | Notes
 --- | ---
-                     |       
-                     |       
 
 
 

--- a/site/content/protocols/coordinate-mediation/3.0/readme.md
+++ b/site/content/protocols/coordinate-mediation/3.0/readme.md
@@ -62,10 +62,6 @@ This protocol expects messages to be encrypted during transmission, and repudiab
 
 Supported Goal Code | Notes
 --- | ---
-                     |       
-                     |       
-
-
 
 ## Message Reference
 


### PR DESCRIPTION
This PR fixes empty goal code tables that were resulting in some ugly styling on the protocol page.