### PR TITLE
[fix] clarify pickup protocol live mode delivery and acknowledge messages

### DIFF
--- a/site/content/protocols/messagepickup/3.0/readme.md
+++ b/site/content/protocols/messagepickup/3.0/readme.md
@@ -128,7 +128,7 @@ Message Type URI: `https://didcomm.org/messagepickup/3.0/delivery-request`
 ```json
 {
     "id": "123456780",
-    "type": "ttps://didcomm.org/messagepickup/3.0/delivery-request",
+    "type": "https://didcomm.org/messagepickup/3.0/delivery-request",
     "body": {
         "limit": 10,
         "recipient_did": "<did for messages>"

--- a/site/content/protocols/messagepickup/3.0/readme.md
+++ b/site/content/protocols/messagepickup/3.0/readme.md
@@ -60,7 +60,7 @@ The `message-received` message is sent by the `recipient` to confirm receipt of 
 
 The `live-delivery-change` message is used to set the state of `live_delivery`.
 
-When _Live Mode_ is enabled, messages that arrive when an existing connection exists are delivered over the connection immediately, rather than being pushed to the queue. See _Live Mode_ below for more details.
+When _Live Mode_ is enabled, messages that arrive when an existing connection exists are delivered over the connection immediately, via a `delivery` message, rather than being pushed to the queue. See _Live Mode_ below for more details. 
 
 ## Security
 
@@ -174,7 +174,7 @@ The ONLY valid type of attachment for this message is a DIDComm v2 Message in en
 The `recipient_did` attribute is only included when responding to a `delivery-request` message that indicates a `recipient_did`.
 
 ### Messages Received
-After receiving messages, the `recipient` sends an acknowledge message indiciating which messages are safe to clear from the queue.
+After receiving messages, the `recipient` **MUST** send an acknowledge message indiciating which messages are safe to clear from the queue.
 
 Message Type URI: `https://didcomm.org/messagepickup/3.0/messages-received`
 
@@ -203,6 +203,8 @@ _Live Mode_ is the practice of delivering newly arriving messages directly to a 
 Messages already in the queue are not affected by _Live Mode_; they must still be requested with `delivery-request` messages.
 
 _Live Mode_ **MUST** only be enabled when a persistent transport is used, such as WebSockets.
+
+If _Live Mode_ is active, messages still **MUST** be delivered via a `delivery` message and the `recipient` **MUST** send an acknowledge message `messages-received`.
 
 Recipients have three modes of possible operation for message delivery with various abilities and level of development complexity:
 


### PR DESCRIPTION
As discussed initially at the DIDComm UG 20240408.

This PR makes clarifications to the Message Pickup v3 protocol, clarifying that when in live mode, delivery and acknowledge messages are still required. This requirement is critical to prevent messages silently never being delivered. If for instance, the mediator thinks the message has been sent over a websocket, but the recipient is not listening to that socket any more, the mediator will think the message was delivered successfully, when in fact it was not (without delivery & acknowledgement). 

This is also illustrated and discussed here: https://github.com/hyperledger/aries-rfcs/issues/760

A similar clarification should be made to the pickup v2 protocol in the Aries RFCs repo, including potentially [this clarification](https://github.com/hyperledger/aries-rfcs/issues/797) (not exactly relevant to v3, as the line in question was removed in v3).

cc: @TelegramSam @genaris 