### PR TITLE
Add documents pointing to didexchange from Aries

### DIFF
--- a/site/content/protocols/didexchange/1.0/readme.md
+++ b/site/content/protocols/didexchange/1.0/readme.md
@@ -1,6 +1,6 @@
 ---
 title: DIDExchange
-publisher: thetechmage
+publisher: TheTechmage
 license: MIT
 piuri: https://didcomm.org/didexchange/1.0
 status: Production

--- a/site/content/protocols/didexchange/1.0/readme.md
+++ b/site/content/protocols/didexchange/1.0/readme.md
@@ -1,0 +1,15 @@
+---
+title: DIDExchange
+publisher: thetechmage
+license: MIT
+piuri: https://didcomm.org/didexchange/1.0
+status: Production
+summary: This protocol allows agents to exchange DIDs during the setup of a connection. Typically used during the use of the Out of Band protocol
+tags: []
+authors: []
+
+---
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/bf3d796cc33ce78ed7cde7f5422b10719a68be21/features/0023-did-exchange
+
+Note: as pointed in the abovementioned link, the version of this protocol is 1.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that this protocol isn't necessary for DIDComm V2.

--- a/site/content/protocols/didexchange/1.1/readme.md
+++ b/site/content/protocols/didexchange/1.1/readme.md
@@ -1,6 +1,6 @@
 ---
 title: DIDExchange
-publisher: thetechmage
+publisher: TheTechmage
 license: MIT
 piuri: https://didcomm.org/didexchange/1.1
 status: Production

--- a/site/content/protocols/didexchange/1.1/readme.md
+++ b/site/content/protocols/didexchange/1.1/readme.md
@@ -1,0 +1,15 @@
+---
+title: DIDExchange
+publisher: thetechmage
+license: MIT
+piuri: https://didcomm.org/didexchange/1.1
+status: Production
+summary: This protocol allows agents to exchange DIDs during the setup of a connection. Typically used during the use of the Out of Band protocol
+tags: []
+authors: []
+
+---
+
+This protocol is defined here: https://github.com/hyperledger/aries-rfcs/tree/d6d2fcf396790c117de02107a448dd64a6240801/features/0023-did-exchange
+
+Note: as pointed in the abovementioned link, the version of this protocol is 1.0 and was defined initially in Hyperledger Aries using DIDComm v1 headers/decorators. Readers should be aware that this protocol isn't necessary for DIDComm V2.


### PR DESCRIPTION
Because DIDExchange is widely used within Aries and they are now linking to didcomm.org, it is in the community's best interest to link to the spec. Should anyone follow the links looking for documentation.