### PR TITLE
fix: media sharing receiver state

### DIFF
--- a/site/content/protocols/media-sharing/1.0/readme.md
+++ b/site/content/protocols/media-sharing/1.0/readme.md
@@ -156,7 +156,7 @@ Description of the fields:
         -  `key`: content encryption key, formatted as an hex string
         -  `iv`: initialization vector, formatted as an hex string
         -  `tag`: authentication tag, formatted as an hex string
-  -  `metadata`: (optional) any relevant information that might the used by an agent to better show the item. Some initial known fields are:
+  -  `metadata`: (optional) any relevant information that might be used by an agent to better show the item. Some initial known fields are:
      -  `preview`: base64 string containing a thumbnail (used mostly for images and videos)
      -  `blurhash`: compact representation of a placeholder for an image (used mostly for images and videos)
      -  `duration`: number containing media duration in seconds (used mostly for videos and audio files)

--- a/site/content/protocols/media-sharing/1.0/readme.md
+++ b/site/content/protocols/media-sharing/1.0/readme.md
@@ -113,7 +113,7 @@ Done -> [*]
 #### Receiver states
 
 - media-requested
-- media-shared
+- media-received
 - done
 
 <!--


### PR DESCRIPTION
## What
Currently in the `media-sharing` [protocol](https://didcomm.org/media-sharing/1.0/) the receiver states are incorrectly stated as `media-shared` instead of `media-received`