### PR TITLE
feat:added vaults support to workflows

### DIFF
--- a/site/content/protocols/vaults/1.0/readme.md
+++ b/site/content/protocols/vaults/1.0/readme.md
@@ -126,6 +126,8 @@ Propose creating a shared vault.
 
 **Expected reply**: `offer` (from provisioner/host or a peer offering to host).
 
+**Workflow binding convention**: When a vault is provisioned for a Workflow 1.0 instance, the `purpose` field SHOULD use the format `workflow:<template_id>#<instance_id>` (e.g., `workflow:student-id-issuance#4b6f...`). This enables the vault host and participants to correlate the vault with its owning workflow. The Workflow protocol's `start` message references the resulting vault via `vault_ref`. Retention and TTL constraints SHOULD align with the expected workflow duration.
+
 ---
 
 ### offer
@@ -448,6 +450,9 @@ Use `vaults/1.0` to set up access + transport, and **Signing 1.0** (recommended)
 * **Leakage**: Encrypted equality indexes leak **existence and equality**; avoid sensitive tags; no range/prefix queries. ([identity.foundation][2])
 * **Immutability backends**: For Arweave, treat "delete" as **cryptographic erasure** (destroy keys) and publish a finalization record listing affected digests. ([SwissBorg Academy][7])
 * **Threshold Decrypt** : Never publish keys on immutable backends. Shares, tokens, and sealed secrets travel only via DIDComm.
+* **Workflow-scoped vaults**: When a vault is bound to a Workflow 1.0 instance, the vault TTL SHOULD be synchronized with the workflow's expected duration. If the workflow completes, the Coordinator or Processor SHOULD trigger `seal`; if canceled, `tombstone`. Key material used for vault encryption SHOULD be wiped promptly after the vault is sealed or tombstoned.
+* **Transient data**: Workflow `$transient` fields (single-cycle ephemeral values) MUST NOT be stored in vaults. They exist only in volatile memory during a single workflow advance cycle.
+* **Guard resolution timing**: When a Workflow Processor resolves vault-backed `$ref` pointers for guard evaluation, the decrypted plaintext MUST be held only in memory for the duration of the evaluation and MUST NOT be cached, logged, or persisted.
 
 ---
 
@@ -455,6 +460,8 @@ Use `vaults/1.0` to set up access + transport, and **Signing 1.0** (recommended)
 
 * Minimize metadata in DIDComm headers and EDV indexes.
 * Consider **group encryption** via JWE general serialization to avoid separate per-recipient blobs. ([IETF Datatracker][5])
+* **Workflow field indexing**: When vault documents store workflow context fields, avoid indexing field names or values that could leak the workflow's purpose or the subject's identity. Use opaque identifiers (e.g., `doc_id` based on random values, not field names) and limit encrypted indexes to structural keys like `workflow_id` and `stage`. Do not index `secret`-level field names or values.
+* **Role-grouped documents**: Grouping sensitive workflow fields into EDV documents by role-access pattern (rather than one document per field) reduces the number of EDV queries observable by the vault host, minimizing metadata leakage about field-level access patterns.
 
 ---
 
@@ -465,6 +472,11 @@ Use `vaults/1.0` to set up access + transport, and **Signing 1.0** (recommended)
 
   * Use Signing 1.0 threshold sessions to collect **approvals** and carry **partial-decrypt shares**.
   * Use Signing 1.0 **sealed-secret** profile (HPKE envelopes bound to tokens) for key delivery.
+* **Composition with Workflow 1.0**:
+  * Workflow templates declare a `sensitivity` map that classifies context fields. Fields with `storage: "vault"` are stored in a Vaults 1.0 EDV and referenced via `$ref` pointers in workflow messages.
+  * The Coordinator provisions the vault before sending Workflow `start`. The `propose.purpose` field uses the convention `workflow:<template_id>#<instance_id>`.
+  * Vault lifecycle is bound to workflow lifecycle: `complete` triggers `seal`, `cancel` triggers `tombstone`.
+  * Agents that support both protocols SHOULD advertise `vault-context` in their Discover Features 2.0 capabilities.
 
 ---
 
@@ -545,6 +557,7 @@ Use `vaults/1.0` to set up access + transport, and **Signing 1.0** (recommended)
 ## Change Log
 
 * **v1.0-draft** — Initial publication
+* **v1.0-draft+wf** — Added workflow binding conventions (`purpose` format), workflow-specific security/privacy guidance, and Workflow 1.0 composition notes.
 
 ---
 

--- a/site/content/protocols/workflow/1.0/readme.md
+++ b/site/content/protocols/workflow/1.0/readme.md
@@ -22,6 +22,7 @@ A DIDComm v2 protocol for orchestrating stateful, multi-step interactions betwee
 - Rendering dynamic UI based on state and participant roles
 - Discovering and fetching templates on-demand
 - Composing with other DIDComm protocols (Issue-Credential, Present-Proof, Payments, etc.)
+- Protecting sensitive context fields via vault-backed references (Vaults 1.0 composition)
 
 ## Motivation
 Agents need a way to coordinate complex, multi-step interactions without hard-coding state machines or protocol logic into every agent. The Workflow protocol provides a declarative, portable format for defining:
@@ -29,6 +30,7 @@ Agents need a way to coordinate complex, multi-step interactions without hard-co
 - UI hints for rendering forms, menus, and status views
 - Issuance and verification profiles that reference other DIDComm protocols
 - Context management and artifact storage across steps
+- Sensitivity classification and vault-backed storage for secrets/PII that must never traverse the wire in plaintext
 
 This enables reusable "workflow templates" that can be published once and executed by any conforming agent, supporting use cases like credential issuance flows, onboarding journeys, approval processes, and interactive service orchestration.
 
@@ -50,12 +52,19 @@ This enables reusable "workflow templates" that can be published once and execut
 - Processors MUST implement idempotency for `advance` operations using `idempotency_key`.
 - Processors MUST bind instances to connections based on the inbound DIDComm connection that delivered `start` (ignoring any `connection_id` in the message body).
 - When a workflow enters a `final` state, the Processor MUST send a `complete` message.
+- Templates that declare `sensitivity` MUST classify every referenced `context` field as `secret`, `pii`, or `plain` (default `plain`).
+- Fields classified as `secret` or `pii` with `storage: "vault"` MUST NOT appear as literal values in `start`, `advance`, or `status` message bodies; they MUST be represented as `$ref` vault references.
+- Coordinators MUST provision a vault (via Vaults 1.0 `propose`/`offer`/`grant-access`) and populate sensitive values into the EDV BEFORE sending `start`.
+- Multiplicity-key expressions MUST NOT reference fields whose sensitivity level is `secret`.
+- `$transient` fields MUST be wiped from instance storage after the advance cycle in which they were supplied.
+- When a workflow instance reaches status `completed`, the Processor SHOULD send a Vaults 1.0 `seal` message to the bound vault. When an instance reaches status `canceled`, the Processor SHOULD send a Vaults 1.0 `tombstone` message.
 
 ## Discoverability
 Agents SHOULD advertise support via Discover-Features v2:
 - Protocol: `https://didcomm.org/workflow/1.0`
 - Capabilities: `discover`, `fetch-template`, `ui:1.0`
 - Optional: Supported protocol actions (e.g., `issue-credential:2.0`, `present-proof:2.0`, `payments:1.0`)
+- Optional: `vault-context` — indicates the agent supports vault-backed sensitive field resolution in workflows
 
 ## Object Model
 
@@ -71,6 +80,52 @@ A workflow template is a versioned, declarative state machine. Key components:
 
 Templates include `display_hints` to define the UI returned in `status` responses. The UI is standardized by "Workflow UI 1.0" (built-in and required). If `display_hints.ui_version` is omitted, it defaults to "1.0".
 
+### Sensitivity (optional)
+
+Templates MAY declare a `sensitivity` map to classify context fields by data-protection level and storage mode. When present, Processors and Coordinators MUST respect the classification rules defined in the Requirements section.
+
+```json
+{
+  "sensitivity": {
+    "default": { "level": "plain", "storage": "plain" },
+    "fields": {
+      "ssn":        { "level": "secret", "storage": "vault" },
+      "full_name":  { "level": "pii",    "storage": "vault" },
+      "studentId":  { "level": "plain",  "storage": "plain" }
+    }
+  }
+}
+```
+
+**Field definitions:**
+- `level`: One of `secret` (cryptographic material, government IDs, passwords), `pii` (personally identifiable information), or `plain` (non-sensitive). Default: `plain`.
+- `storage`: One of `vault` (store in a Vaults 1.0 EDV and reference via `$ref`), `encrypted` (encrypt inline using JWE — reserved for future use), or `plain` (store as-is in context). Default: `plain`.
+
+When `storage` is `vault`, the Coordinator MUST provision a vault before `start` and replace literal values in `context` with `$ref` pointers (see Instance model below). Fields with `storage: "vault"` SHOULD be grouped into EDV documents by role-access pattern (e.g., all fields readable by the `holder` role in one document) rather than one EDV document per field.
+
+If the `sensitivity` map is absent, all fields default to `plain`/`plain` and no vault integration is required.
+
+### Display Hints: Sensitivity Behavior (optional)
+
+Templates MAY include sensitivity-aware rendering hints inside `display_hints`:
+
+```json
+{
+  "display_hints": {
+    "sensitivity_behavior": {
+      "secret": { "render": "masked", "mask_format": "***-**-{last4}" },
+      "pii":    { "render": "masked_toggle", "mask_format": "{first1}***" },
+      "plain":  { "render": "visible" }
+    }
+  }
+}
+```
+
+- `render`: One of `masked` (always masked), `masked_toggle` (masked with user-reveal option), `visible` (shown as-is).
+- `mask_format`: Optional format string. `{last4}`, `{first1}` are built-in tokens; literal characters pass through.
+
+Coordinators SHOULD respect `sensitivity_behavior` when rendering UI components that display context or artifact values.
+
 ### Instance (Processor storage)
 A workflow instance is scoped to a DIDComm thread (`thid`). The Processor MUST persist:
 ```json
@@ -82,8 +137,17 @@ A workflow instance is scoped to a DIDComm thread (`thid`). The Processor MUST p
   "participants": { "holder": { "did": "did:..." } },
   "state": "stateName",
   "section": "string-optional",
-  "context": {},
+  "context": {
+    "studentId": "A-123",
+    "ssn": { "$ref": { "vault_id": "urn:edv:...:vaultABC", "doc_id": "z19role-holder-secrets", "digest": "sha256-BASE64URL(...)" } },
+    "full_name": { "$ref": { "vault_id": "urn:edv:...:vaultABC", "doc_id": "z19role-holder-pii", "digest": "sha256-BASE64URL(...)" } }
+  },
   "artifacts": {},
+  "vault_ref": {
+    "vault_id": "urn:edv:...:vaultABC",
+    "base_url": "https://edv.example.com/edvs/vaultABC",
+    "lifecycle": "active"
+  },
   "status": "active|paused|canceled|completed|error",
   "history": [
     {
@@ -99,6 +163,12 @@ A workflow instance is scoped to a DIDComm thread (`thid`). The Processor MUST p
 }
 ```
 
+**Vault reference (`vault_ref`)**:
+- `vault_ref` is set by the Processor when a `start` message includes a vault reference. It records the vault identity and lifecycle state (`active`, `sealed`, `retired`).
+- `$ref` objects in `context` or `artifacts` are pointers to EDV documents. They follow a simplified form of the Vaults 1.0 `ContentRef`: `vault_id` + `doc_id` + `digest`. The `capability` (ZCAP) is not stored per-reference; instead the Processor uses the root capability from `vault_ref` or a role-scoped grant.
+- When the Processor needs the actual value (e.g., for guard evaluation or action building), it MUST resolve the `$ref` by fetching the EDV document, decrypting the JWE, and verifying the digest. If resolution fails, the operation MUST fail with `vault_unavailable`.
+- If no `vault_ref` is present, the instance operates in plain mode (backwards compatible — all context/artifact values are inline).
+
 **Connection binding**:
 - `connection_id` is a Processor-local identifier bound at Start from the inbound DIDComm connection that delivered the Start message.
 - Coordinators SHOULD NOT send a `connection_id` over the wire; if present, Processors MUST ignore it. The value differs on each agent and is not used for interop.
@@ -109,12 +179,15 @@ Templates declare an instance policy:
 - `singleton_per_connection`: At most one active instance per connection
 - `multi_per_connection`: Multiple instances allowed; optional `multiplicity_key` expression over `context` for deduplication
 
+> **Restriction**: Multiplicity-key expressions MUST NOT reference fields whose template `sensitivity.level` is `secret`. This prevents sensitive data from appearing in deduplication indexes. Fields with `pii` level MAY be referenced only if the Processor stores multiplicity keys as HMAC digests (not plaintext).
+
 ## Data Conventions (normative)
 
 ### Expressions & Guards
 - Guards and multiplicity expressions MUST be deterministic and side-effect-free.
 - Guards evaluate over `{ context, participants, artifacts }`.
 - Attribute planning supports `context|static|compute` modes with required semantics.
+- When a guard expression references a vault-backed field (`$ref`), the Processor MUST resolve the reference before evaluation. If the vault is unreachable or the digest does not match, the guard evaluation MUST fail and the Processor MUST return `action_failed` (not `guard_failed`) to distinguish infrastructure failures from logical guard failures.
 
 ### Action Resolution
 - **Messaging actions**: `typeURI` is a DIDComm message type (e.g., `https://didcomm.org/issue-credential/2.0/offer-credential`), resolved via `profile_ref` into `catalog`. Messages are built solely from template + instance data.
@@ -169,6 +242,14 @@ Coordinator → Processor: `discover` with optional filters
 Coordinator → Processor: `fetch-template` with `template_id`
 - Processor → Coordinator: `template` with full template definition
 
+### 7) Vault-Aware Flow (when sensitivity is declared)
+1. **Template declares sensitivity**: The template includes a `sensitivity` map classifying `ssn` as `secret/vault` and `full_name` as `pii/vault`.
+2. **Coordinator provisions vault**: Before sending `start`, the Coordinator executes Vaults 1.0: `propose` → `offer` → `grant-access` (granting the Processor read+write). Sensitive values are encrypted and stored in the EDV, grouped by role-access (e.g., one document for holder-readable secrets, another for holder-readable PII).
+3. **Coordinator sends `start`**: The `context` contains `$ref` pointers instead of literal values for vault-backed fields. A `vault_ref` object identifies the vault.
+4. **Processor resolves on demand**: When an `advance` triggers a guard or action that needs a vault-backed value, the Processor fetches and decrypts from the EDV, verifies the digest, and uses the plaintext ephemerally (never persisted outside the vault).
+5. **Transient fields**: If `advance` supplies `$transient: ["otp_code"]`, the Processor uses `otp_code` for the current cycle only and wipes it from instance storage after the advance completes.
+6. **Completion**: When the workflow reaches a `final` state, the Processor sends Vaults 1.0 `seal` to freeze the vault. On `cancel`, the Processor sends `tombstone`.
+
 ## Security
 - Use authcrypt for all messages.
 - Minimize sensitive values in `context`; encrypt at rest.
@@ -176,6 +257,11 @@ Coordinator → Processor: `fetch-template` with `template_id`
 - Thread integrity: validate `thid` continuity.
 - Capability checks via Discover-Features v2.
 - Secure storage and protect against replay.
+- **Vault-backed fields**: Sensitive values classified as `secret` or `pii` with `storage: "vault"` MUST NOT appear in DIDComm message bodies. Only `$ref` pointers travel over the wire.
+- **Digest verification**: Processors MUST verify the `digest` in every `$ref` after decrypting the EDV document. A mismatch MUST be treated as tampering and reported via `problem-report` with code `vault_ref_invalid`.
+- **Vault lifecycle**: Coordinators SHOULD provision ephemeral vaults (short TTL) for workflow-scoped sensitive data. On workflow completion, vaults SHOULD be sealed; on cancellation, tombstoned.
+- **History scrubbing**: Processors MUST NOT record resolved plaintext values in the `history` array. History entries MAY reference `$ref` pointers but MUST NOT contain the resolved content.
+- **Transient field safety**: `$transient` values MUST be held only in volatile memory during the advance cycle and MUST NOT be written to persistent storage, logs, or history.
 
 ## Message Reference
 
@@ -233,7 +319,15 @@ Body:
   "template_version": "1.0.0",
   "instance_id": "4b6f...",
   "participants": { "holder": { "did": "did:example:alice" } },
-  "context": { "name": "Alice", "studentId": "A-123" },
+  "context": {
+    "name": "Alice",
+    "studentId": "A-123",
+    "ssn": { "$ref": { "vault_id": "urn:edv:...:vaultABC", "doc_id": "z19role-holder-secrets", "digest": "sha256-BASE64URL(...)" } }
+  },
+  "vault_ref": {
+    "vault_id": "urn:edv:...:vaultABC",
+    "base_url": "https://edv.example.com/edvs/vaultABC"
+  },
   "allow_discover": true,
   "template_hash": "hex-optional"
 }
@@ -246,6 +340,9 @@ Semantics:
 - **Participant defaults**: If `participants` is omitted or incomplete, the Processor SHOULD set `participants.issuer.did` to the inbound connection `myDid` and `participants.holder.did` to the inbound connection `theirDid`.
 - Processor MUST enforce `instance_policy` (singleton/multi + dedupe) and create or return the instance.
 - `thid` SHOULD equal `instance_id`.
+- `vault_ref` (optional): When present, identifies the pre-provisioned Vaults 1.0 vault for this workflow instance. The Coordinator MUST have already completed the Vaults 1.0 `propose`/`offer`/`grant-access` flow and stored sensitive context values in the vault BEFORE sending `start`.
+- `$ref` objects in `context`: Any value that is a JSON object with a single `$ref` key is treated as a vault reference pointer. The inner object MUST contain `vault_id`, `doc_id`, and `digest`. The Processor MUST NOT attempt to resolve `$ref` pointers at `start` time unless required by multiplicity-key evaluation.
+- `multiplicity_hint` (optional, string): A pre-computed HMAC hint for multiplicity deduplication when the multiplicity key references `pii`-level fields. Avoids a vault round-trip at start time.
 
 ### advance
 Message Type URI: `https://didcomm.org/workflow/1.0/advance`
@@ -256,7 +353,8 @@ Body:
   "instance_id": "4b6f...",
   "event": "offer",
   "idempotency_key": "btn-offer-01",
-  "input": { "optional": "values from UI forms" }
+  "input": { "optional": "values from UI forms", "otp_code": "123456" },
+  "$transient": ["otp_code"]
 }
 ```
 
@@ -265,6 +363,11 @@ Atomic semantics:
 - Optional action execution (messaging or local)
 - State persistence with idempotency
 - Send `complete` when entering a `final` state
+
+**Transient fields (`$transient`)**:
+- `$transient` is an optional array of field names from `input` that MUST NOT be persisted beyond the current advance cycle.
+- The Processor MUST use transient fields only for guard evaluation and action execution within this single advance, then wipe them from all storage (instance, logs, history).
+- Transient fields MUST NOT be vault-backed (they exist only for a single cycle and are never stored). If a transient field name collides with a vault-backed `context` field, the transient value takes precedence for the current cycle only and the vault reference is restored afterward.
 
 ### status
 Message Type URI: `https://didcomm.org/workflow/1.0/status`
@@ -282,7 +385,8 @@ Request body:
     "did": "optional",
     "participantKey": "optional"
   },
-  "capabilities": ["ui:video", "ui:table"]
+  "capabilities": ["ui:video", "ui:table"],
+  "resolve_vault_refs": false
 }
 ```
 
@@ -294,6 +398,11 @@ Response includes:
 - `ui` (when `include_ui=true`): rendered UI components filtered by role/state
 - `ui_profile` (echo of requested profile)
 - `assets` (shared media referenced by UI items)
+
+**Vault reference resolution in `status` responses:**
+- `resolve_vault_refs` (default `false`): When `true`, the Processor SHOULD resolve `$ref` pointers in `context` and `artifacts` before returning the response, replacing them with decrypted plaintext values. The Processor MUST verify digests and MUST redact fields whose sensitivity level exceeds the `viewer.role`'s access (e.g., a viewer with `holder` role sees PII but not `secret`-level fields intended for `issuer` only).
+- When `resolve_vault_refs` is `false` (default), the response returns `$ref` pointers as-is and the Coordinator resolves them client-side using its own vault capability.
+- If resolution is requested but the vault is unreachable, the Processor MUST return the `$ref` pointer unchanged and include a `~warning` header attachment with code `vault_unavailable`.
 
 ### problem-report
 Message Type URI: `https://didcomm.org/workflow/1.0/problem-report`
@@ -408,6 +517,9 @@ Localization applies to human-readable fields (e.g., UI labels, error messages).
 - Idempotency: Duplicate `advance` with same `idempotency_key` MUST be no-ops.
 - Thread integrity: Validate `thid` continuity across messages.
 - Participant derivation: If not provided, SHOULD populate from connection's `myDid`/`theirDid`.
+- Vault reference integrity: Every `$ref` in `context` or `artifacts` MUST contain `vault_id`, `doc_id`, and `digest`. If `vault_ref` is present on the instance, all `$ref.vault_id` values MUST match `vault_ref.vault_id`.
+- Sensitivity consistency: If the template declares `sensitivity.fields.X.storage = "vault"`, then field `X` in `start.context` MUST be a `$ref` object (not a literal value). Processors MUST reject a `start` message that passes literal values for vault-required fields.
+- Transient exclusion: Fields listed in `$transient` MUST NOT appear in `sensitivity.fields` with `storage: "vault"`.
 
 ## Errors (Problem-Report codes)
 Use standard DIDComm problem-report with these codes:
@@ -420,13 +532,16 @@ Use standard DIDComm problem-report with these codes:
 - `not_authorized` — Requester is not permitted to view or fetch the template
 - `not_found_remote_template` — Remote does not have the referenced template/version (or hash mismatch)
 - `multiplicity_violation` — Start violated singleton policy
+- `vault_unavailable` — Vault EDV is unreachable or returned an error during `$ref` resolution
+- `vault_ref_invalid` — A `$ref` pointer is malformed, references a non-existent document, or the digest does not match the decrypted content
+- `sensitivity_violation` — A `start` or `advance` message passed a literal value for a field that the template requires to be vault-backed
 
 ## Processor Conformance
 A conforming Processor MUST:
 1. Validate & store templates on `publish-template`.
 2. Enforce multiplicity on `start`.
 3. Process `advance` atomically and implement idempotency.
-4. Resolve actions from template + instance only.
+4. Resolve actions from template + instance + vault references. When an action or guard requires a vault-backed field, the Processor MUST resolve the `$ref`, verify the digest, and use the decrypted value.
 5. Map inbound DIDComm protocol messages to workflow events.
 6. Provide `status` with `allowed_events`, `action_menu`, and optional `ui`.
 7. Send `workflow/1.0/complete` on entering a `final` state.
@@ -435,6 +550,11 @@ A conforming Processor MUST:
 10. Bind `connection_id` from the inbound DIDComm connection; ignore any `connection_id` in `start`.
 11. MAY attempt `discover` + `fetch-template` when `start` references an unknown template and `allow_discover != false`; MUST validate/store then continue.
 12. SHOULD use the same `thid` across `start` → `discover`/`workflows` → `fetch-template`/`template` → `status`.
+13. When `vault_ref` is present, the Processor MUST track vault lifecycle state (`active`, `sealed`, `retired`) on the instance.
+14. On workflow `complete`, the Processor MUST send a Vaults 1.0 `seal` message to the bound vault. On workflow `cancel`, the Processor MUST send a Vaults 1.0 `tombstone` message.
+15. The Processor MUST NOT record resolved plaintext from vault-backed fields in `history`, logs, or any persistent store other than the vault itself.
+16. The Processor MUST wipe `$transient` fields from all storage immediately after the advance cycle completes.
+17. The Processor MUST reject `start` messages that pass literal values for fields declared as `storage: "vault"` in the template `sensitivity` map (return `sensitivity_violation`).
 
 ## Coordinator Conformance (recommended)
 A conforming Coordinator SHOULD:
@@ -443,15 +563,19 @@ A conforming Coordinator SHOULD:
 - Fire `advance(event)` on button clicks with `idempotency_key`.
 - Avoid sending credential/schema IDs in messages—use profile IDs.
 - Implement `discover` and `fetch-template` with authorization controls; include `hash` in `workflows` when `include_hash=true`.
+- When a template declares `sensitivity` with `storage: "vault"` fields, provision a Vaults 1.0 vault, store sensitive values in the EDV grouped by role-access, and send only `$ref` pointers in `start.context`.
+- Respect `sensitivity_behavior` in `display_hints` when rendering UI (masking, toggle-reveal).
+- On workflow completion or cancellation, confirm the vault has been sealed or tombstoned (the Processor handles this, but Coordinators SHOULD verify via vault `notify` or `status`).
 
 ## Composition
 The Workflow protocol composes with other DIDComm protocols by referencing their message types in action definitions. Supported protocols:
 - Issue-Credential 2.0
 - Present-Proof 2.0
 - Payments 1.0
+- Vaults 1.0 (vault-backed sensitive field storage, lifecycle binding)
 - (Any DIDComm protocol with defined message types)
 
-New protocols (e.g., payments) require no change to Workflow 1.0: add an action whose `typeURI` equals the new DIDComm message type and a matching profile in `catalog`.
+New protocols (e.g., payments) require no change to Workflow 1.0: add an action whose `typeURI` equals the new DIDComm message type and a matching profile in `catalog`. Vaults 1.0 integration is activated by the presence of a `sensitivity` map in the template and a `vault_ref` in the instance; agents without vault support degrade gracefully to plaintext context fields.
 
 ## Versioning & Capabilities
 - Template `version` uses semver.
@@ -473,3 +597,6 @@ Name / Link | Implementation Notes
 - Advanced UI components (video, file upload, signature capture)
 - Workflow monitoring and analytics
 - Workflow versioning and migration strategies
+- Per-field ZCAP capabilities for fine-grained vault access control (currently role-grouped)
+- `encrypted` storage mode (inline JWE without vault) for moderate-sensitivity fields
+- Cross-workflow vault sharing (multiple workflow instances referencing the same vault)


### PR DESCRIPTION
## Summary

Adds Vaults 1.0 composition to the Workflow protocol and corresponding workflow-binding conventions to the Vaults protocol. Together, these changes let agents protect sensitive context fields (secrets, PII) via vault-backed `$ref` pointers instead of sending plaintext over the wire.

## Changes

### Workflow 1.0

- **Sensitivity classification**: Templates can now declare a `sensitivity` map that classifies context fields as `secret`, `pii`, or `plain`, with storage mode `vault`, `encrypted` (reserved), or `plain`.
- **Vault-backed `$ref` pointers**: Fields with `storage: "vault"` are stored in a Vaults 1.0 EDV and represented as `$ref` objects (`vault_id` + `doc_id` + `digest`) in workflow messages — literal values never travel over the wire.
- **`vault_ref` on instances**: Workflow instances track their bound vault identity and lifecycle state (`active`, `sealed`, `retired`).
- **Transient fields (`$transient`)**: `advance` messages can declare ephemeral input fields that are used for a single cycle (e.g., OTP codes) and wiped immediately after.
- **Display hints for sensitivity**: Templates can specify masking behavior per sensitivity level (`masked`, `masked_toggle`, `visible`) with format tokens.
- **Guard/action resolution**: Processors resolve `$ref` pointers on demand, verify digests, and hold plaintext only in memory. Digest mismatch = tampering, vault unreachable = `vault_unavailable` error.
- **Lifecycle binding**: Workflow `complete` triggers vault `seal`; `cancel` triggers vault `tombstone`.
- **New error codes**: `vault_unavailable`, `vault_ref_invalid`, `sensitivity_violation`.
- **Updated conformance requirements**: 5 new Processor requirements (13-17) and 3 new Coordinator recommendations covering vault provisioning, sensitivity enforcement, and transient field safety.
- **Vault-aware flow**: New section (7) documenting the end-to-end vault-integrated workflow.
- **Multiplicity restriction**: Multiplicity-key expressions must not reference `secret`-level fields.
- **History scrubbing**: Resolved plaintext must never appear in history entries, logs, or persistent storage outside the vault.
- **Future work**: Per-field ZCAP, inline JWE mode, cross-workflow vault sharing.

### Vaults 1.0 

- **Workflow binding convention**: `propose.purpose` field format `workflow:<template_id>#<instance_id>` for correlating vaults with workflow instances.
- **Workflow-scoped vault guidance**: TTL synchronization, `seal` on complete, `tombstone` on cancel, key material wiping.
- **Transient data rule**: Workflow `$transient` fields must never be stored in vaults.
- **Guard resolution timing**: Decrypted plaintext for guard evaluation must be held only in memory, never cached or persisted.
- **Field indexing privacy**: Guidance on avoiding metadata leakage when indexing workflow context fields in EDV encrypted indexes.
- **Role-grouped documents**: Recommendation to group sensitive fields by role-access pattern to reduce observable query patterns.
- **Composition section**: New Workflow 1.0 composition notes covering sensitivity maps, vault provisioning, lifecycle binding, and capability advertisement.
- **Changelog**: Added `v1.0-draft+wf` entry.

## Design Decisions

- **`$ref` pointers over inline JWE**: Chose vault-backed references over inline encryption because it centralizes key management, enables role-scoped access, and keeps message size constant regardless of secret size.
- **Role-grouped EDV documents**: Grouping fields by role-access (rather than one doc per field) reduces the number of EDV queries visible to the vault host, minimizing metadata leakage.
- **Digest verification mandatory**: Every `$ref` resolution verifies a content digest to detect tampering at the vault layer.
- **Graceful degradation**: Agents without vault support see plaintext context fields — no vault integration is required unless the template declares a `sensitivity` map.
